### PR TITLE
Stop ignoring main for tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: TDR Run Tests
 on:
   push:
     branches-ignore:
-      - main
       - release-*
 permissions:
   id-token: write


### PR DESCRIPTION
We need the tests to run on the main branch so that the version bump PRs
have the checks run against them.
