### PR TITLE
Constructor params duplicated causing tabindex issue

### DIFF
--- a/app/all.ts
+++ b/app/all.ts
@@ -2,18 +2,15 @@ import { NestedNavigation, InputType } from "../src/nationalarchives";
 import { MultiSelectSearch } from "../src/nationalarchives";
 
 window.onload = () => {
-  const checkboxTrees: NodeListOf<HTMLUListElement> =
-    document.querySelectorAll("#checkbox-tree");
-  checkboxTrees.forEach((tree) => {
+  const trees: NodeListOf<HTMLUListElement> =
+    document.querySelectorAll("[role=tree]");
+  trees.forEach((tree) => {
     const nestedNavigation = new NestedNavigation(tree);
-    nestedNavigation.initialiseFormListeners(InputType.checkboxes);
-  });
-
-  const radioTrees: NodeListOf<HTMLUListElement> =
-    document.querySelectorAll("#radio-tree");
-  radioTrees.forEach((tree) => {
-    const nestedNavigation = new NestedNavigation(tree);
-    nestedNavigation.initialiseFormListeners(InputType.radios);
+    if (tree.hasAttribute("aria-multiselectable")) {
+      nestedNavigation.initialiseFormListeners(InputType.checkboxes);
+    } else {
+      nestedNavigation.initialiseFormListeners(InputType.radios);
+    }
   });
 
   const multiSelects: NodeListOf<HTMLElement> | null =

--- a/app/all.ts
+++ b/app/all.ts
@@ -2,29 +2,19 @@ import { NestedNavigation, InputType } from "../src/nationalarchives";
 import { MultiSelectSearch } from "../src/nationalarchives";
 
 window.onload = () => {
-  const checkboxTreeItems: NodeListOf<HTMLUListElement> =
+  const checkboxTrees: NodeListOf<HTMLUListElement> =
     document.querySelectorAll("#checkbox-tree");
-  const checkboxTree: HTMLUListElement | null =
-    document.querySelector("#checkbox-tree");
-  const treeItemList: HTMLUListElement[] = [];
-  if (checkboxTree != null) {
-    checkboxTreeItems.forEach((item) => treeItemList.push(item));
-    const nestedNavigation = new NestedNavigation(checkboxTree, treeItemList);
-
+  checkboxTrees.forEach((tree) => {
+    const nestedNavigation = new NestedNavigation(tree);
     nestedNavigation.initialiseFormListeners(InputType.checkboxes);
-  }
+  });
 
-  const radioTreeItems: NodeListOf<HTMLUListElement> =
+  const radioTrees: NodeListOf<HTMLUListElement> =
     document.querySelectorAll("#radio-tree");
-  const radioTree: HTMLUListElement | null =
-    document.querySelector("#radio-tree");
-  const radioTreeItemList: HTMLUListElement[] = [];
-  if (radioTree != null) {
-    radioTreeItems.forEach((item) => radioTreeItemList.push(item));
-    const nestedNavigation = new NestedNavigation(radioTree, radioTreeItemList);
-
+  radioTrees.forEach((tree) => {
+    const nestedNavigation = new NestedNavigation(tree);
     nestedNavigation.initialiseFormListeners(InputType.radios);
-  }
+  });
 
   const multiSelects: NodeListOf<HTMLElement> | null =
     document.querySelectorAll("[data-module=multi-select-search]");

--- a/src/nationalarchives/components/nested-navigation/nested-navigation.ts
+++ b/src/nationalarchives/components/nested-navigation/nested-navigation.ts
@@ -87,8 +87,10 @@ export class NestedNavigation {
 
     const firstSelected: HTMLLIElement | null =
       this.tree.querySelector("[role=treeitem]");
-    if (firstSelected) firstSelected.tabIndex = 0;
-    // this.updateFocus(firstSelected);
+    if (firstSelected) {
+      firstSelected.tabIndex = 0;
+      this.currentFocus = firstSelected;
+    }
   };
 
   replaceCheckboxWithSpan: (

--- a/src/nationalarchives/components/nested-navigation/nested-navigation.ts
+++ b/src/nationalarchives/components/nested-navigation/nested-navigation.ts
@@ -344,8 +344,6 @@ export class NestedNavigation {
     ev,
     inputType
   ) => {
-    console.log(ev.key);
-
     switch (ev.key) {
       case "Enter":
       case " ":

--- a/src/nationalarchives/components/nested-navigation/nested-navigation.unit.test.ts
+++ b/src/nationalarchives/components/nested-navigation/nested-navigation.unit.test.ts
@@ -36,7 +36,7 @@ const createNestedNavigation: (
   tree?: HTMLUListElement | undefined
 ) => NestedNavigation = (navOption, element, tree) => {
   const el = tree != null ? tree : document.createElement("ul");
-  const navigation = new NestedNavigation(el, [el]);
+  const navigation = new NestedNavigation(el);
   if (element != null) {
     navigation.setFocusToItem(element);
   }
@@ -49,7 +49,6 @@ const createNestedNavigation: (
 describe.each([InputType.checkboxes, InputType.radios])(
   "Nested Navigation %s",
   (classNameValue) => {
-
     const inputType = document.createElement("input");
     const inputTypeValue =
       classNameValue === "checkboxes" ? "checkbox" : "radio";
@@ -175,7 +174,7 @@ describe.each([InputType.checkboxes, InputType.radios])(
         const li = document.createElement("li");
         const tree = document.createElement("ul");
         tree.appendChild(li);
-        const nestedNavigation = new NestedNavigation(tree, [tree]);
+        const nestedNavigation = new NestedNavigation(tree);
         const event = createKeyboardEvent("Home");
 
         nestedNavigation.handleKeyDown(event, classNameValue);
@@ -200,28 +199,27 @@ describe.each([InputType.checkboxes, InputType.radios])(
     describe("handleExpanders", () => {
       it("should toggle the correct elements", () => {
         const toggleNode = jest.fn();
+        const tree = document.createElement("ul");
         const li = document.createElement("li");
         const setFocusToItem = jest.fn();
         const nestedNavigation = createNestedNavigation(
           { setFocusToItem, toggleNode },
-          li
+          li,
+          tree
         );
         const input = createInputElement();
         const ul = document.createElement("ul");
         ul.setAttribute("id", input.id.replace("expander-", "node-group-"));
         li.appendChild(ul);
-        document.body.appendChild(li);
+        tree.appendChild(li);
 
         nestedNavigation.handleExpanders(input, classNameValue);
-
         expect(toggleNode).toHaveBeenCalledWith(
           li,
           input.id.replace("expander-", ""),
           classNameValue
         );
         expect(setFocusToItem).toHaveBeenCalledWith(li);
-
-        document.body.removeChild(li);
       });
     });
 
@@ -528,40 +526,28 @@ describe.each([InputType.checkboxes, InputType.radios])(
           events[event] = [callback];
         });
         ul.appendChild(button);
-        document.body.appendChild(ul);
-        const nestedNavigation = createNestedNavigation({});
+        // document.body.appendChild(ul);
+        const nestedNavigation = createNestedNavigation({}, undefined, ul);
         nestedNavigation.initialiseFormListeners(classNameValue);
 
         expect(events.click?.length).toEqual(1);
       });
 
       it("should update the expanded state for the checkboxes", () => {
+        const tree = document.createElement("ul");
         const input = createInputElement();
         input.setAttribute("role", "group");
         input.id = classNameValue;
-        document.body.appendChild(input);
+        tree.appendChild(input);
         const updateExpanded = jest.fn();
-        const nestedNavigation = createNestedNavigation({ updateExpanded });
+        const nestedNavigation = createNestedNavigation(
+          { updateExpanded },
+          undefined,
+          tree
+        );
         nestedNavigation.initialiseFormListeners(classNameValue);
 
         expect(updateExpanded).toHaveBeenCalledWith(input, classNameValue);
-      });
-
-      it("should add a focus handler to the checkboxes", () => {
-        const events: { [key: string]: EventListenerOrEventListenerObject[] } =
-          {};
-
-        const ul = document.createElement("ul");
-        ul.setAttribute("role", "tree");
-
-        ul.addEventListener = jest.fn((event, callback) => {
-          events[event] = [callback];
-        });
-        document.body.appendChild(ul);
-        const nestedNavigation = new NestedNavigation(ul, [ul]);
-        nestedNavigation.initialiseFormListeners(classNameValue);
-
-        expect(events.focus?.length).toEqual(1);
       });
 
       it("should replace the checkboxes with spans", () => {
@@ -574,12 +560,16 @@ describe.each([InputType.checkboxes, InputType.radios])(
         li.appendChild(label);
         li.setAttribute("class", `govuk-${classNameValue}__item`);
         ul.appendChild(li);
-        document.body.appendChild(ul);
+        // document.body.appendChild(ul);
         const replaceCheckboxWithSpan = jest.fn();
 
-        const nestedNavigation = createNestedNavigation({
-          replaceCheckboxWithSpan,
-        });
+        const nestedNavigation = createNestedNavigation(
+          {
+            replaceCheckboxWithSpan,
+          },
+          undefined,
+          ul
+        );
         nestedNavigation.initialiseFormListeners(classNameValue);
 
         expect(replaceCheckboxWithSpan).toHaveBeenCalledWith(input, label);
@@ -589,7 +579,7 @@ describe.each([InputType.checkboxes, InputType.radios])(
     describe("getTree", () => {
       it("should get the tree", () => {
         const el = document.createElement("ul");
-        const navigation = new NestedNavigation(el, [el]);
+        const navigation = new NestedNavigation(el);
 
         expect(navigation.getTree()).toEqual(el);
       });
@@ -609,7 +599,7 @@ describe.each([InputType.checkboxes, InputType.radios])(
         const tree = document.createElement("ul");
         const li = document.createElement("li");
         tree.appendChild(li);
-        const nestedNavigation = new NestedNavigation(tree, [tree]);
+        const nestedNavigation = new NestedNavigation(tree);
         nestedNavigation.setFocusToItem = setFocusToItem;
 
         nestedNavigation.updateFocus();

--- a/src/nationalarchives/components/nested-navigation/nested-navigation.unit.test.ts
+++ b/src/nationalarchives/components/nested-navigation/nested-navigation.unit.test.ts
@@ -526,7 +526,6 @@ describe.each([InputType.checkboxes, InputType.radios])(
           events[event] = [callback];
         });
         ul.appendChild(button);
-        // document.body.appendChild(ul);
         const nestedNavigation = createNestedNavigation({}, undefined, ul);
         nestedNavigation.initialiseFormListeners(classNameValue);
 
@@ -560,7 +559,6 @@ describe.each([InputType.checkboxes, InputType.radios])(
         li.appendChild(label);
         li.setAttribute("class", `govuk-${classNameValue}__item`);
         ul.appendChild(li);
-        // document.body.appendChild(ul);
         const replaceCheckboxWithSpan = jest.fn();
 
         const nestedNavigation = createNestedNavigation(

--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -75,7 +75,7 @@
   {% elseif params.inputType == 'checkbox' %}
     {% set className = 'checkboxes' %}
   {% endif %}
-  <ul tabindex="0" class="tna-tree__root-list" id="{{ params.inputType }}-tree" role="tree"{% if params.inputType == 'checkboxes' %} aria-multiselectable="true"{% endif %}>
+  <ul tabindex="0" class="tna-tree__root-list" id="{{ params.inputType }}-tree" role="tree"{% if params.inputType == 'checkbox' %} aria-multiselectable="true"{% endif %}>
     {% for node in params.items %}
       {{ navigationItem(node, params.inputType, className, 1, loop.length, loop.index) }}
     {% endfor %}


### PR DESCRIPTION
Constructor call was being passed the same variable in both params causing the 2nd param to be used incorrectly as the list of 'treeitems' (i.e. tree nodes). Those nodes therefore weren't having tabindex set correctly.

Changed references to `document.querySelector` in favour of `this.tree.querySelector` case of multiple trees on one page.

Also changed instantiation to use the presence or absence of `aria-multiselectable` attribute instead of `id=radio-tree|checkbox-tree`. 