### PR TITLE
Suggestions to improve screen reader announcements

### DIFF
--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -30,6 +30,7 @@
         >
       <div class="tna-tree__node-item__container">
         <button
+                        aria-hidden="true"
                         class="tna-tree__expander js-tree__expander--{{ className }}"
                         tabindex="-1"
                         id="{{ className }}-expander-{{ item.id }}"
@@ -75,7 +76,9 @@
   {% elseif params.inputType == 'checkbox' %}
     {% set className = 'checkboxes' %}
   {% endif %}
-  <ul tabindex="0" class="tna-tree__root-list" id="{{ params.inputType }}-tree" role="tree"{% if params.inputType == 'checkbox' %} aria-multiselectable="true"{% endif %}>
+
+  <p class="govuk-hint" id="tree-view-description">Navigate files and folders using arrow keys.</p>
+  <ul aria-label="File selection" aria-describedby="tree-view-description" class="tna-tree__root-list" id="{{ params.inputType }}-tree" role="tree"{% if params.inputType == 'checkbox' %} aria-multiselectable="true"{% endif %}>
     {% for node in params.items %}
       {{ navigationItem(node, params.inputType, className, 1, loop.length, loop.index) }}
     {% endfor %}


### PR DESCRIPTION
Relates to Jira card [TDR-2882](https://national-archives.atlassian.net/browse/TDR-2882). 

2 x improvements to screen reader announcements. Both would require implementation in TDR back-end. 

[TDR-2882]: https://national-archives.atlassian.net/browse/TDR-2882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Also removes the tabindex from root `<ul>` element because we are setting tabindex to zero on the first element in the list. 