### PR TITLE
Replace button with span.

### DIFF
--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -29,14 +29,14 @@
                 aria-posinset="{{pos}}"
         >
       <div class="tna-tree__node-item__container">
-        <button
+        <span
                         aria-hidden="true"
                         class="tna-tree__expander js-tree__expander--{{ className }}"
                         tabindex="-1"
                         id="{{ className }}-expander-{{ item.id }}"
                 >
           <span class="govuk-visually-hidden">Expand</span>
-        </button>
+        </span>
         {% if className == 'checkboxes' %}
           <div class="govuk-{{ className }}__item">
             <input


### PR DESCRIPTION
This has been replaced in the front end to fix a bug that happens when
you click the button before the js has loaded.
This change is to keep the template and the frontend in sync.
