### PR TITLE
Changing height to max-height for scenarios with fewer options

### DIFF
--- a/src/nationalarchives/components/multi-select-search/_index.scss
+++ b/src/nationalarchives/components/multi-select-search/_index.scss
@@ -1,6 +1,6 @@
 .tna-multi-select-search__list-container {
   position: relative;
-  height: 225px;
+  max-height: 225px;
   overflow-y: auto;
   overflow-x: hidden;
   background-color: #fff;


### PR DESCRIPTION
Prevents a spacing issue when there are only, e.g. two languages. Currently MSS has a fixed height. 
See [TDR-2991](https://national-archives.atlassian.net/browse/TDR-2991)

[TDR-2991]: https://national-archives.atlassian.net/browse/TDR-2991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ