### PR TITLE
Fix the typo in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "stylelint": "^14.14.0",
         "stylelint-config-standard": "^29.0.0",
         "stylelint-config-standard-scss": "^5.0.0",
-        "ts-jest": "^29.0.5",
+        "ts-jest": "^29.0.3",
         "ts-loader": "^9.4.1",
         "webpack": "^5.74.0",
         "webpack-cli": "^4.10.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "sass-copy": "copyfiles -u 2 'src/nationalarchives/**/*.scss' package",
     "test": "jest",
     "compile": "webpack --mode production",
-    "build": "npm-s sass-compile sass-copy compile",
+    "build": "npm-run-all sass-compile sass-copy compile",
     "lint": "eslint src app lib",
     "stylelint": "stylelint **/*.scss",
     "checks": "npm-run-all test lint stylelint",


### PR DESCRIPTION
The deploy job reported this as an error but then carried on regardless
so I think the exit codes are a bit weird.
Anyway, this should fix it, the current version of the deployed package
is empty.
