### PR TITLE
Accessibility Audit Action - Custom elements (A) - Tree view for file selection

### DIFF
--- a/src/nationalarchives/components/nested-navigation/_index.scss
+++ b/src/nationalarchives/components/nested-navigation/_index.scss
@@ -9,6 +9,10 @@
   margin-bottom: 1em;
 }
 
+.tna-tree .govuk-label {
+  white-space: nowrap;
+}
+
 .tna-tree__root-list {
   background-image: linear-gradient(180deg, #F8F8F8 25%, #ffffff 25%, #ffffff 50%, #F8F8F8 50%, #F8F8F8 75%, #ffffff 75%, #ffffff 100%);
   background-size: 100% 180px;
@@ -48,8 +52,8 @@
 }
 
 .tna-tree__nested-list--radios::before {
-  margin: -6px 0 0 calc(-2px + var(--directory-icon-width) / 2);
-  height: calc(100% + 8px);
+  margin: -2px 0 0 calc(-2px + var(--directory-icon-width) / 2);
+  height: calc(100% + 4px);
 }
 
 .tna-tree__node-item__container {
@@ -117,98 +121,78 @@
   cursor: pointer;
 }
 
-[role="treeitem"]:focus > div > div > .tna-radios-directory__label,
-[role="treeitem"]:hover > div > div > .tna-radios-directory__label {
-  position: relative;
-}
-
-[role="treeitem"]:focus > div > div > .tna-radios-directory__label:before,
-[role="treeitem"]:hover > div > div > .tna-radios-directory__label:before {
-  content: " ";
-  background-color: #b1b4b69a;
-  border-radius: 16px;
-  width: 40px;
-  height: 36px;
-  display: block;
-  position: absolute;
-  top: 0px;
-  left: -8px;
-}
-
 [role="treeitem"]:focus {
   background-color: rgba(210, 250, 249, 0.25);
   outline: 3px solid rgb(210, 250, 249);
   outline-offset: 1px;
 }
 
-$input-types: "checkboxes", "radios";
+.tna-tree [role="treeitem"][aria-expanded="false"]>ul {
+  display: none;
+}
 
-@each $input-type in $input-types {
+.tna-tree [role="treeitem"][aria-expanded="true"]>ul {
+  display: block;
+}
 
+/*
+* Using same CSS as govuk-frontend checkboxes component:
+* https: //github.com/alphagov/govuk-frontend/blob/main/package/govuk/components/checkboxes/_index.scss
+* Not including the IE8 stuff.
+* */
+[role="treeitem"]:hover > div .govuk-checkboxes__input + .govuk-checkboxes__label:before,
+[role="treeitem"]:focus > div .govuk-checkboxes__input + .govuk-checkboxes__label:before {
+  border-width: 4px;
 
-  .tna-tree [role="treeitem"][aria-expanded="false"]>ul {
-    display: none;
+  // When colours are overridden, the yellow box-shadow becomes invisible
+  // which means the focus state is less obvious. By adding a transparent
+  // outline, which becomes solid (text-coloured) in that context, we ensure
+  // the focus remains clearly visible.
+  outline: $govuk-focus-width solid transparent;
+  outline-offset: 1px;
+
+  // When in an explicit forced-color mode, we can use the Highlight system
+  // color for the outline to better match focus states of native controls
+  @media screen and (forced-colors: active),
+  (-ms-high-contrast: active) {
+    outline-color: Highlight;
   }
 
-  .tna-tree [role="treeitem"][aria-expanded="true"]>ul {
-    display: block;
+  box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
+}
+
+// Hover state for checkboxes.
+[role="treeitem"]:hover>div .govuk-checkboxes__input+.govuk-checkboxes__label:before {
+  box-shadow: 0 0 0 $govuk-focus-width $govuk-hover-colour;
+}
+
+/*
+* Using same CSS as govuk-frontend radio component:
+* https: //github.com/alphagov/govuk-frontend/blob/main/src/govuk/components/radios/_index.scss
+* */
+
+// Focus state for small radios.
+[role="treeitem"]:focus > .govuk-radios__item .govuk-radios__input:not(:disabled) + .govuk-radios__label:before {
+  border-width: 4px;
+
+  outline: $govuk-focus-width solid transparent;
+  outline-offset: 1px;
+
+  @media screen and (forced-colors: active),
+  (-ms-high-contrast: active) {
+    outline-color: Highlight;
   }
 
-  // https://github.com/alphagov/govuk-frontend/issues/1453#issue-455823968
-  .tna-tree .govuk-label govuk-#{$input-type}__label {
-    white-space: nowrap;
-  }
-
-  /*
-   * Using same CSS as govuk-frontend checkboxes component:
-   * https://github.com/alphagov/govuk-frontend/blob/137b806d7c308f98f75f8c78ecfdb7f760b27d39/package/govuk/components/checkboxes/_index.scss#L128
-   * Not including the IE8 stuff.
-   * */
-
-  [role="treeitem"]:focus>.govuk-#{$input-type}__item>.govuk-label govuk-#{$input-type}__label::before,
-  [role="treeitem"]:focus>.tna-tree__node-item__container>.govuk-#{$input-type}__item>.govuk-label govuk-#{$input-type}__label::before {
-    border-width: 1px;
-
-    // When colours are overridden, the yellow box-shadow becomes invisible
-    // which means the focus state is less obvious. By adding a transparent
-    // outline, which becomes solid (text-coloured) in that context, we ensure
-    // the focus remains clearly visible.
-    outline: $govuk-focus-width solid transparent;
-    outline-offset: 1px;
-
-    // When in an explicit forced-color mode, we can use the Highlight system
-    // color for the outline to better match focus states of native controls
-    @media screen and (forced-colors: active),
-    (-ms-high-contrast: active) {
-      outline-color: Highlight;
-    }
-
-    box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
-  }
-
-  [role="treeitem"][aria-selected="true"]>.govuk-#{$input-type}__item>.govuk-#{$input-type}__label::after,
-  [role="treeitem"][aria-selected="true"]>.tna-tree__node-item__container>.govuk-#{$input-type}__item>.govuk-#{$input-type}__label::after {
-    opacity: 1;
-  }
+  box-shadow: 0 0 0 4px $govuk-focus-colour;
 }
 
 // Hover state for small radios.
-//
-// We use a hover state for small radios because the touch target size
-// is so much larger than their visible size, and so we need to provide
-// feedback to the user as to which radio they will select when their
-// cursor is outside of the visible area.
-[role="treeitem"]:focus>.govuk-radios__item .govuk-radios__input:not(:disabled)+.govuk-radios__label:before,
-[role="treeitem"]:hover>.govuk-radios__item .govuk-radios__input:not(:disabled)+.govuk-radios__label:before{
+[role="treeitem"]:hover > .govuk-radios__item .govuk-radios__input:not(:disabled) + .govuk-radios__label:before {
   box-shadow: 0 0 0 $govuk-hover-width $govuk-hover-colour;
 }
 
 // Because we've overridden the border-shadow provided by the focus state,
-// we need to redefine that too.
-//
-// We use two box shadows, one that restores the original focus state [1]
-// and another that then applies the hover state [2].
-[role="treeitem"]:hover>.govuk-radios__item .govuk-radios__input+.govuk-radios__label:before {
+[role="treeitem"]:hover > .govuk-radios__item .govuk-radios__input + .govuk-radios__label:before {
   box-shadow:
     0 0 0 $govuk-focus-width+1 $govuk-focus-colour, // 1
     0 0 0 $govuk-hover-width $govuk-hover-colour; // 2
@@ -218,8 +202,8 @@ $input-types: "checkboxes", "radios";
  * Styles copied from this thread for indeterminate/mixed checkbox state:
  * https://github.com/alphagov/govuk-frontend/issues/1453#issue-455823968
  * */
-[role="treeitem"][aria-checked="mixed"]>.govuk-checkboxes__item>.govuk-label .govuk-checkboxes__label::after,
-[role="treeitem"][aria-checked="mixed"]>.tna-tree__node-item__container>.govuk-checkboxes__item>.govuk-checkboxes__label::after {
+[role="treeitem"][aria-checked="mixed"] > .govuk-checkboxes__item > .govuk-label .govuk-checkboxes__label::after,
+[role="treeitem"][aria-checked="mixed"] > .tna-tree__node-item__container > .govuk-checkboxes__item > .govuk-checkboxes__label::after {
   transform: rotate(0);
   border: none;
   top: 0;
@@ -231,15 +215,38 @@ $input-types: "checkboxes", "radios";
   opacity: 1;
 }
 
-.tna-radios-directory {
+.tna-tree__radios-directory {
   display: flex;
   height: 100%;
 }
 
-.tna-radios-directory__label {
+.tna-tree__radios-directory__label {
   display: flex;
   gap: 10px;
-  padding: 8px 0 8px;
+  padding: 8px 34px 8px;
+  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAWCAYAAADafVyIAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgB7ZXRDcIgFEWvxgEcoRtUN8ANGIER2KArsAFuABuoIziBbkA3wPdI+iU1iPLHSU5CQ+GGR8IDgIkMZMz4IA/4gQ1vNAwDhBBvk957zAQNj+QTlUSlVMzhnFtOckElu0+TUkporWGMEfTpyBnl3MgzD1ZPwIQQuIS5+ylRoORHLtU3WGuXtSqVaO2SmXEcU6lqSQG8OaWiBVs0pgf0gB7QAwrglsn9eI82nPg15X474f/cyesLxTel2GiK/tEAAAAASUVORK5CYII=");
+  background-repeat: no-repeat;
+  background-size: 24px 22px;
+  background-position-y: 8px;
+  z-index: 1;
+}
+
+[role="treeitem"]:focus>div>.tna-tree__radios-directory,
+[role="treeitem"]:hover>div>.tna-tree__radios-directory {
+  position: relative;
+}
+
+[role="treeitem"]:focus>div>.tna-tree__radios-directory:before,
+[role="treeitem"]:hover>div>.tna-tree__radios-directory:before {
+  content: " ";
+  background-color: #b1b4b6;
+  border-radius: 100%;
+  width: 40px;
+  height: 40px;
+  display: block;
+  position: absolute;
+  top: 0px;
+  left: -8px;
 }
 
 /* Accommodate for lack of button so alignment is ok */

--- a/src/nationalarchives/components/nested-navigation/_index.scss
+++ b/src/nationalarchives/components/nested-navigation/_index.scss
@@ -10,8 +10,9 @@
 }
 
 .tna-tree__root-list {
-    background-image: linear-gradient(180deg, #F8F8F8 22.22%, #ffffff 22.22%, #ffffff 50%, #F8F8F8 50%, #F8F8F8 72.22%, #ffffff 72.22%, #ffffff 100%);
-    background-size: 100% 180px;
+  background-image: linear-gradient(180deg, #F8F8F8 25%, #ffffff 25%, #ffffff 50%, #F8F8F8 50%, #F8F8F8 75%, #ffffff 75%, #ffffff 100%);
+  background-size: 100% 180px;
+  background-position: 0 -2px;
 }
 
 .tna-tree__root-list,
@@ -57,7 +58,7 @@
   align-items: flex-start;
 }
 
-.tna-tree__node-item__container > * {
+.tna-tree__node-item__container>* {
   flex-shrink: 0;
 }
 
@@ -71,6 +72,7 @@
   width: 24px;
   display: inline-block;
   align-self: baseline;
+  z-index: 1;
 }
 
 .tna-tree__expander {
@@ -101,14 +103,42 @@
   border-color: $govuk-link-colour;
 }
 
-.tna-tree [role="treeitem"][aria-expanded="true"] > .tna-tree__node-item__container > .tna-tree__expander::before {
+.tna-tree [role="treeitem"][aria-expanded="true"]>.tna-tree__node-item__container>.tna-tree__expander::before {
   @include govuk-shape-arrow($direction: down, $base: 20px);
 
   border-color: $govuk-link-colour;
 }
 
-.tna-tree [role="treeitem"][aria-expanded="true"] > .tna-tree__node-item__container > .tna-tree__expander::before {
+.tna-tree [role="treeitem"][aria-expanded="true"]>.tna-tree__node-item__container>.tna-tree__expander::before {
   left: 10px;
+}
+
+[role="treeitem"]:hover {
+  cursor: pointer;
+}
+
+[role="treeitem"]:focus > div > div > .tna-radios-directory__label,
+[role="treeitem"]:hover > div > div > .tna-radios-directory__label {
+  position: relative;
+}
+
+[role="treeitem"]:focus > div > div > .tna-radios-directory__label:before,
+[role="treeitem"]:hover > div > div > .tna-radios-directory__label:before {
+  content: " ";
+  background-color: #b1b4b69a;
+  border-radius: 16px;
+  width: 40px;
+  height: 36px;
+  display: block;
+  position: absolute;
+  top: 0px;
+  left: -8px;
+}
+
+[role="treeitem"]:focus {
+  background-color: rgba(210, 250, 249, 0.25);
+  outline: 3px solid rgb(210, 250, 249);
+  outline-offset: 1px;
 }
 
 $input-types: "checkboxes", "radios";
@@ -116,11 +146,11 @@ $input-types: "checkboxes", "radios";
 @each $input-type in $input-types {
 
 
-  .tna-tree [role="treeitem"][aria-expanded="false"] > ul {
+  .tna-tree [role="treeitem"][aria-expanded="false"]>ul {
     display: none;
   }
 
-  .tna-tree [role="treeitem"][aria-expanded="true"] > ul {
+  .tna-tree [role="treeitem"][aria-expanded="true"]>ul {
     display: block;
   }
 
@@ -135,9 +165,9 @@ $input-types: "checkboxes", "radios";
    * Not including the IE8 stuff.
    * */
 
-  [role="treeitem"]:focus > .govuk-#{$input-type}__item > .govuk-label govuk-#{$input-type}__label::before,
-  [role="treeitem"]:focus > .tna-tree__node-item__container > .govuk-#{$input-type}__item > .govuk-label govuk-#{$input-type}__label::before {
-    border-width: 4px;
+  [role="treeitem"]:focus>.govuk-#{$input-type}__item>.govuk-label govuk-#{$input-type}__label::before,
+  [role="treeitem"]:focus>.tna-tree__node-item__container>.govuk-#{$input-type}__item>.govuk-label govuk-#{$input-type}__label::before {
+    border-width: 1px;
 
     // When colours are overridden, the yellow box-shadow becomes invisible
     // which means the focus state is less obvious. By adding a transparent
@@ -148,34 +178,57 @@ $input-types: "checkboxes", "radios";
 
     // When in an explicit forced-color mode, we can use the Highlight system
     // color for the outline to better match focus states of native controls
-    @media screen and (forced-colors: active), (-ms-high-contrast: active) {
+    @media screen and (forced-colors: active),
+    (-ms-high-contrast: active) {
       outline-color: Highlight;
     }
 
     box-shadow: 0 0 0 $govuk-focus-width $govuk-focus-colour;
   }
 
-  [role="treeitem"][aria-selected="true"] > .govuk-#{$input-type}__item > .govuk-#{$input-type}__label::after,
-  [role="treeitem"][aria-selected="true"] > .tna-tree__node-item__container > .govuk-#{$input-type}__item > .govuk-#{$input-type}__label::after {
+  [role="treeitem"][aria-selected="true"]>.govuk-#{$input-type}__item>.govuk-#{$input-type}__label::after,
+  [role="treeitem"][aria-selected="true"]>.tna-tree__node-item__container>.govuk-#{$input-type}__item>.govuk-#{$input-type}__label::after {
     opacity: 1;
   }
+}
 
-  /*
-   * Styles copied from this thread:
-   * https://github.com/alphagov/govuk-frontend/issues/1453#issue-455823968
-   * */
-  [role="treeitem"][aria-checked="mixed"] > .govuk-#{$input-type}__item > .govuk-label govuk-#{$input-type}__label::after,
-  [role="treeitem"][aria-checked="mixed"] > .tna-tree__node-item__container > .govuk-#{$input-type}__item > .govuk-#{$input-type}__label::after {
-    transform: rotate(0);
-    border: none;
-    top: 0;
-    bottom: 0;
-    margin: auto;
-    height: 6px;
-    width: 22px;
-    background: currentcolor;
-    opacity: 1;
-  }
+// Hover state for small radios.
+//
+// We use a hover state for small radios because the touch target size
+// is so much larger than their visible size, and so we need to provide
+// feedback to the user as to which radio they will select when their
+// cursor is outside of the visible area.
+[role="treeitem"]:focus>.govuk-radios__item .govuk-radios__input:not(:disabled)+.govuk-radios__label:before,
+[role="treeitem"]:hover>.govuk-radios__item .govuk-radios__input:not(:disabled)+.govuk-radios__label:before{
+  box-shadow: 0 0 0 $govuk-hover-width $govuk-hover-colour;
+}
+
+// Because we've overridden the border-shadow provided by the focus state,
+// we need to redefine that too.
+//
+// We use two box shadows, one that restores the original focus state [1]
+// and another that then applies the hover state [2].
+[role="treeitem"]:hover>.govuk-radios__item .govuk-radios__input+.govuk-radios__label:before {
+  box-shadow:
+    0 0 0 $govuk-focus-width+1 $govuk-focus-colour, // 1
+    0 0 0 $govuk-hover-width $govuk-hover-colour; // 2
+}
+
+/*
+ * Styles copied from this thread for indeterminate/mixed checkbox state:
+ * https://github.com/alphagov/govuk-frontend/issues/1453#issue-455823968
+ * */
+[role="treeitem"][aria-checked="mixed"]>.govuk-checkboxes__item>.govuk-label .govuk-checkboxes__label::after,
+[role="treeitem"][aria-checked="mixed"]>.tna-tree__node-item__container>.govuk-checkboxes__item>.govuk-checkboxes__label::after {
+  transform: rotate(0);
+  border: none;
+  top: 0;
+  bottom: 0;
+  margin: auto;
+  height: 6px;
+  width: 22px;
+  background: currentcolor;
+  opacity: 1;
 }
 
 .tna-radios-directory {
@@ -187,17 +240,13 @@ $input-types: "checkboxes", "radios";
   display: flex;
   gap: 10px;
   padding: 8px 0 8px;
-  cursor: pointer;
-  -ms-touch-action: manipulation;
-  touch-action: manipulation;
 }
 
 /* Accommodate for lack of button so alignment is ok */
-.tna-tree__item > .govuk-checkboxes__item {
+.tna-tree__item>.govuk-checkboxes__item {
   margin-left: calc(var(--item-expander-btn-width));
 }
 
 .tna-tree__node-item__radio {
   margin-left: var(--item-expander-btn-width);
 }
-

--- a/src/nationalarchives/components/nested-navigation/_index.scss
+++ b/src/nationalarchives/components/nested-navigation/_index.scss
@@ -5,7 +5,7 @@
 
   overflow-x: auto;
   overflow-y: auto;
-  max-height: 90vh;
+  max-height: 70vh;
   margin-bottom: 1em;
 }
 

--- a/src/nationalarchives/components/nested-navigation/_index.scss
+++ b/src/nationalarchives/components/nested-navigation/_index.scss
@@ -223,30 +223,18 @@
 .tna-tree__radios-directory__label {
   display: flex;
   gap: 10px;
-  padding: 8px 34px 8px;
-  background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAWCAYAAADafVyIAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgB7ZXRDcIgFEWvxgEcoRtUN8ANGIER2KArsAFuABuoIziBbkA3wPdI+iU1iPLHSU5CQ+GGR8IDgIkMZMz4IA/4gQ1vNAwDhBBvk957zAQNj+QTlUSlVMzhnFtOckElu0+TUkporWGMEfTpyBnl3MgzD1ZPwIQQuIS5+ylRoORHLtU3WGuXtSqVaO2SmXEcU6lqSQG8OaWiBVs0pgf0gB7QAwrglsn9eI82nPg15X474f/cyesLxTel2GiK/tEAAAAASUVORK5CYII=");
+  padding: 8px 36px 8px;
+  margin-bottom: 0;
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACMAAAAfCAYAAABtYXSPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAADRSURBVHgB7dbhDYIwEAXgp3EQNkA36AiM0BHYgBXYoG7QbqCO4AS6QdmgXk34Za9a0xBC7kteAiGlR68JBYTYqIHiKSGRB+WIynaZZ6FpGiilPh445zARujxRnlhA0FqHFGvtvEIXVHTAH7quQ9/3GMdR0a2lTAXDb5QzCrErE3nvYxtT++mXKBT6+tLYrhLGmHmsTk2YbRO3gaO2bd/tqilbTCyEvgZL2WNFpBiOFMORYjhSDEeK4ayqmBzu/FsjKjVh7q8dz7cD6rtTrhCigheLWbuwMSK7MAAAAABJRU5ErkJggg==');
   background-repeat: no-repeat;
-  background-size: 24px 22px;
-  background-position-y: 8px;
+  background-size: 35px 31px;
+  background-position: 0 4px;
   z-index: 1;
 }
 
-[role="treeitem"]:focus>div>.tna-tree__radios-directory,
-[role="treeitem"]:hover>div>.tna-tree__radios-directory {
-  position: relative;
-}
-
-[role="treeitem"]:focus>div>.tna-tree__radios-directory:before,
-[role="treeitem"]:hover>div>.tna-tree__radios-directory:before {
-  content: " ";
-  background-color: #b1b4b6;
-  border-radius: 100%;
-  width: 40px;
-  height: 40px;
-  display: block;
-  position: absolute;
-  top: 0px;
-  left: -8px;
+[role="treeitem"]:focus>div>.tna-tree__radios-directory .tna-tree__radios-directory__label,
+[role="treeitem"]:hover>div>.tna-tree__radios-directory .tna-tree__radios-directory__label {
+  background-image: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACMAAAAfCAYAAABtYXSPAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAJvSURBVHgB7ZfNbhJRFMf/d4BqQhewmdlOcVtEn0BM3UjBwhNIn6C4NU0A40dcMTHuYVNZMgQRF43BXV21byBbumJDIh3heu6UqTgfTYkDZcEvuQkzcy/8OPdjzmG4hkajEQlu3D3gnCc5oOKyzcuAAWdjoAljpOdyuZ5XR+Yu0VEDIV4lgSR8hjFWG1/8KrtJSfYbrfbXAynETxchIqAo56XQndPG5y8F+zP2r0inOOG8hCUhMVbK7D4twy4jIjLhEw1LZgK8yKVT2pWMWCNiauhjxOpU/3SEVlPHcDh0fIEsK3h5eIit2D34wGBijB6KNWTK6O1OldFczvbYS6egqiqSyaRjtK7rMAwD2oePkBUF/wtJdJ+lU4/ZNCo/7R2ETD6fR7VadZWhf4LteBxv3r2HH1B0okGEeBZzks1mUSgUoGka3r5+hfDm5o3HbsfvY2fnifNBcKMQDFAQOOanWCyaEfpxcjLXuG/Hx1Bk2ZSaJcDYI4lEHngNrNVq4pBybdFoFJVKRZwbN27WlPf7547f4gxqEDM7yI7XAhYkEglzunyDX8p4IkTcFvCikLBCrGW8WMt4sZbxQpzAPawGA0laERkKypk05vw7VgCSaUr4fbH0VNMVKmMkSpJEXdPFLSLKF5F2mi/KscH27TlwOBw2UwjR/EZR5NnLgaijTCnrjqhjaDFXrOvzfh/1+hH8JrYVQ2bvb+rhqA6uhFrtEtUyRSwJqtHKucxuybp2lLfTCAmhCBbHgCJStiLiKWMKUcVAiXqJpJ7DZ2gLd7kx2nertdl1A6dS2WnSLnLluaM1PeF7XJxndIyI3evV9w/wDAf+i+feDAAAAABJRU5ErkJggg==');
 }
 
 /* Accommodate for lack of button so alignment is ok */

--- a/src/nationalarchives/components/nested-navigation/nested-navigation.stories.ts
+++ b/src/nationalarchives/components/nested-navigation/nested-navigation.stories.ts
@@ -88,26 +88,16 @@ ExpandNodeAndFocus.args = {
 // should expand the node when the expander is clicked
 ExpandNodeAndFocus.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
-  await userEvent.click(canvas.getAllByText("Expand")[0]);
-
-  await expect(canvas.getByText("Vanilla cake.xlsx")).toBeVisible();
-
-  await expect(
-    canvas.getByRole("treeitem", { name: /Old recipes/ })
-  ).toHaveFocus();
-};
-
-export const SelectInputAndFocus = Template.bind({});
-SelectInputAndFocus.args = {
-  inputType: "radio",
-};
-SelectInputAndFocus.play = async ({ canvasElement }) => {
-  const canvas = within(canvasElement);
-  // Click label
-  await userEvent.click(canvas.getByText("Baking-powder Nov 1999.docx"));
+  await userEvent.click(
+    canvas.getByRole("treeitem", { name: /^Directory - Old recipes/ })
+  );
 
   await expect(
-    canvas.getByLabelText("Baking-powder Nov 1999.docx")
+    canvas.getByRole("treeitem", { name: "Vanilla cake.xlsx" })
+  ).toBeVisible();
+
+  await expect(
+    canvas.getByRole("treeitem", { name: /^Directory - Old recipes/ })
   ).toHaveFocus();
 };
 
@@ -167,6 +157,13 @@ MultipleSelectChildSetsParentToIndeterminate.play = async ({
   // Cannot run a test on indeterminate states because we're using
   // aria-checked incorrectly. It needs to be on the checkbox not the
   // parent tree element. When completed use `expect().toBePartiallyChecked()`
+  await expect(
+    canvas.getByRole("treeitem", { name: /^Non dairy/ })
+  ).toHaveAttribute("aria-checked", "mixed");
+
+  await expect(
+    canvas.getByRole("treeitem", { name: /^Cupcakes/ })
+  ).toHaveAttribute("aria-checked", "mixed");
 };
 
 //  should select the last child when end is pressed on the expanded root node
@@ -183,14 +180,24 @@ MultipleSelectParentSelectsAllChildren.play = async ({ canvasElement }) => {
   await userEvent.click(canvas.getAllByText("Expand")[4]);
   await userEvent.click(canvas.getByText("Cupcakes") as Element);
 
-  await expect(canvas.getByLabelText("Red velvet.pptx")).toBeChecked();
-  await expect(canvas.getByLabelText("Non dairy")).toBeChecked();
-  await expect(canvas.getByLabelText("Carrot cake.pptx")).toBeChecked();
-  await expect(canvas.getByLabelText("Vegan banana.png")).toBeChecked();
   await expect(
-    canvas.getByLabelText("Lemon and poppyseed gf.json")
+    canvas.getByRole("treeitem", { name: /^Red velvet.pptx/ })
   ).toBeChecked();
-  await expect(canvas.getByLabelText("Coffee and walnut.gif")).toBeChecked();
+  await expect(
+    canvas.getByRole("treeitem", { name: /^Non dairy/ })
+  ).toBeChecked();
+  await expect(
+    canvas.getByRole("treeitem", { name: /^Carrot cake.pptx/ })
+  ).toBeChecked();
+  await expect(
+    canvas.getByRole("treeitem", { name: /^Vegan banana.png/ })
+  ).toBeChecked();
+  await expect(
+    canvas.getByRole("treeitem", { name: /^Lemon and poppyseed gf.json/ })
+  ).toBeChecked();
+  await expect(
+    canvas.getByRole("treeitem", { name: /^Coffee and walnut.gif/ })
+  ).toBeChecked();
 };
 
 // should expand the node when the right arrow is pressed on the closed parent node
@@ -225,7 +232,7 @@ KeyboardNavigateSelect.play = async ({ canvasElement }) => {
 
   await expect(
     canvas.getByRole("treeitem", { name: "Baking-powder Nov 1999.docx" })
-  ).toBeChecked();
+  ).toHaveAttribute("aria-selected", "true");
 };
 
 // should expand the node when the right arrow is pressed on the closed parent node
@@ -237,34 +244,27 @@ ClickSelectAndKeyboardDeselect.args = {
 ClickSelectAndKeyboardDeselect.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
 
-  await userEvent.click(canvas.getByText("Baking-powder Nov 1999.docx"));
+  await userEvent.click(
+    canvas.getByRole("treeitem", { name: "Baking-powder Nov 1999.docx" })
+  );
 
+  // await expect(
+  //   canvas.getByRole("treeitem", { name: "Baking-powder Nov 1999.docx" })
+  // ).toBeChecked();
   await expect(
     canvas.getByRole("treeitem", { name: "Baking-powder Nov 1999.docx" })
-  ).toBeChecked();
-
-  await expect(
-    canvas.getByRole("radio", { name: "Baking-powder Nov 1999.docx" })
-  ).toBeChecked();
+  ).toHaveAttribute("aria-selected", "true");
 
   await userEvent.keyboard("[ArrowDown]");
   await userEvent.keyboard("[Space]");
 
   await expect(
     canvas.getByRole("treeitem", { name: "Baking-powder Nov 1999.docx" })
-  ).not.toBeChecked();
-
-  await expect(
-    canvas.getByRole("radio", { name: "Baking-powder Nov 1999.docx" })
-  ).not.toBeChecked();
+  ).not.toHaveAttribute("aria-selected", "true");
 
   await expect(
     canvas.getByRole("treeitem", { name: "Baking-powder Nov 2020.docx" })
-  ).toBeChecked();
-
-  await expect(
-    canvas.getByRole("radio", { name: "Baking-powder Nov 2020.docx" })
-  ).toBeChecked();
+  ).toHaveAttribute("aria-selected", "true");
 };
 
 // should expand the node when the right arrow is pressed on the closed parent node
@@ -298,21 +298,13 @@ KeyboardNavigateSelectAndDeselect.play = async ({ canvasElement }) => {
 
   await expect(
     canvas.getByRole("treeitem", { name: "Baking-powder Nov 1999.docx" })
-  ).toBeChecked();
-
-  await expect(
-    canvas.getByRole("radio", { name: "Baking-powder Nov 1999.docx" })
-  ).toBeChecked();
+  ).toHaveAttribute("aria-selected", "true");
 
   await userEvent.keyboard("[Enter]");
 
   await expect(
     canvas.getByRole("treeitem", { name: "Baking-powder Nov 1999.docx" })
-  ).not.toBeChecked();
-
-  await expect(
-    canvas.getByRole("radio", { name: "Baking-powder Nov 1999.docx" })
-  ).not.toBeChecked();
+  ).not.toHaveAttribute("aria-selected", "true");
 };
 
 // // should expand the node when the right arrow is pressed on the closed parent node

--- a/src/nationalarchives/components/nested-navigation/nested-navigation.stories.ts
+++ b/src/nationalarchives/components/nested-navigation/nested-navigation.stories.ts
@@ -17,17 +17,19 @@ export default {
       const doc = parser.parseFromString(storyFn(), "text/html");
       wrapper.appendChild(doc.body.firstElementChild as HTMLElement);
 
-      // Also use this wrapper element to init the MSS js.
-      const trees: NodeListOf<HTMLUListElement> =
-        wrapper.querySelectorAll("[role=tree]");
-      trees.forEach((tree) => {
-        const nestedNavigation = new NestedNavigation(tree);
-        if (tree.hasAttribute("aria-multiselectable")) {
-          nestedNavigation.initialiseFormListeners(InputType.checkboxes);
-        } else {
-          nestedNavigation.initialiseFormListeners(InputType.radios);
-        }
-      });
+      document.addEventListener("DOMContentLoaded", (event) => {
+        // Also use this wrapper element to init the MSS js.
+        const trees: NodeListOf<HTMLUListElement> =
+          wrapper.querySelectorAll("[role=tree]");
+        trees.forEach((tree) => {
+          const nestedNavigation = new NestedNavigation(tree);
+          if (tree.hasAttribute("aria-multiselectable")) {
+            nestedNavigation.initialiseFormListeners(InputType.checkboxes);
+          } else {
+            nestedNavigation.initialiseFormListeners(InputType.radios);
+          }
+        });
+      }, { once : true });
 
       return wrapper;
     },
@@ -67,11 +69,11 @@ const Template = ({ ...args }) => {
   return createTree({ ...args });
 };
 
-export const SingleSelectExample = Template.bind({});
-SingleSelectExample.args = {
+export const DefaultSingle = Template.bind({});
+DefaultSingle.args = {
   inputType: "radio",
 };
-SingleSelectExample.play = async ({ canvasElement }) => {
+DefaultSingle.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
 
   // should load the page with the directories collapsed, i.e. children invisible
@@ -101,13 +103,12 @@ ExpandNodeAndFocus.play = async ({ canvasElement }) => {
   ).toHaveFocus();
 };
 
-export const SelectTreeItemAndFocus = Template.bind({});
-SelectTreeItemAndFocus.args = {
+export const ClickItemAndFocus = Template.bind({});
+ClickItemAndFocus.args = {
   inputType: "radio",
 };
-SelectTreeItemAndFocus.play = async ({ canvasElement }) => {
+ClickItemAndFocus.play = async ({ canvasElement }) => {
   const canvas = within(canvasElement);
-  // Click label
   await userEvent.click(
     canvas.getByRole("treeitem", { name: /Baking-powder Nov 2020/ })
   );
@@ -115,6 +116,28 @@ SelectTreeItemAndFocus.play = async ({ canvasElement }) => {
   await expect(
     canvas.getByRole("treeitem", { name: /Baking-powder Nov 2020/ })
   ).toHaveFocus();
+};
+
+export const ClickItemAndUpdateFileSelected = Template.bind({});
+ClickItemAndUpdateFileSelected.args = {
+  inputType: "radio",
+};
+ClickItemAndUpdateFileSelected.play = async ({ canvasElement }) => {
+  const canvas = within(canvasElement);
+  await userEvent.click(
+    canvas.getByRole("treeitem", { name: /Baking-powder Nov 2020/ })
+  );
+
+  const allTexts = canvas.getAllByText(/Baking-powder Nov 2020/)
+  await expect(
+    allTexts.length
+  ).toBeGreaterThan(1)
+
+  // Last item should be the 'File Selected' component
+  await expect(
+    allTexts.pop()?.textContent
+  ).toEqual("Baking-powder Nov 2020.docx")
+
 };
 
 export const ExpandSelectAndFocus = Template.bind({});
@@ -133,8 +156,8 @@ ExpandSelectAndFocus.play = async ({ canvasElement }) => {
   ).toHaveFocus();
 };
 
-export const MultipleSelectExample = Template.bind({});
-MultipleSelectExample.args = {
+export const DefaultMultiple = Template.bind({});
+DefaultMultiple.args = {
   inputType: "checkbox",
 };
 

--- a/src/nationalarchives/components/nested-navigation/nested-navigation.stories.ts
+++ b/src/nationalarchives/components/nested-navigation/nested-navigation.stories.ts
@@ -271,9 +271,8 @@ ClickSelectAndKeyboardDeselect.play = async ({ canvasElement }) => {
     canvas.getByRole("treeitem", { name: "Baking-powder Nov 1999.docx" })
   );
 
-  // await expect(
-  //   canvas.getByRole("treeitem", { name: "Baking-powder Nov 1999.docx" })
-  // ).toBeChecked();
+  // Currently treeitems are not recognised by Testing Library as having a
+  // selected state so can't use `await expect.toBeChecked();`. Maybe a bug.
   await expect(
     canvas.getByRole("treeitem", { name: "Baking-powder Nov 1999.docx" })
   ).toHaveAttribute("aria-selected", "true");

--- a/src/nationalarchives/components/nested-navigation/nested-navigation.ts
+++ b/src/nationalarchives/components/nested-navigation/nested-navigation.ts
@@ -3,6 +3,11 @@ export enum InputType {
   checkboxes = "checkboxes",
 }
 
+export enum InputTypeHtmlAttrValue {
+  radios = "radio",
+  checkboxes = "checkbox",
+}
+
 export class NestedNavigation {
   private readonly tree: HTMLUListElement;
   private readonly treeItems: NodeListOf<HTMLElement>;
@@ -80,12 +85,28 @@ export class NestedNavigation {
       }
     });
 
+    // Hide all inputs from SR so that they don't conflict with
+    // the tree role
+    this.removeFocusFromInputs(inputType);
+
+    // Set the first item as focusable
     const firstSelected: HTMLLIElement | null =
       this.tree.querySelector("[role=treeitem]");
     if (firstSelected) {
       firstSelected.tabIndex = 0;
       this.currentFocus = firstSelected;
     }
+  };
+
+  removeFocusFromInputs: (inputType: InputType) => void = (inputType) => {
+    const inputs: NodeListOf<HTMLInputElement> = this.tree.querySelectorAll(
+      `input[type=${InputTypeHtmlAttrValue[inputType]}]`
+    );
+
+    inputs.forEach((input) => {
+      input.tabIndex = -1;
+      input.setAttribute("aria-hidden", "true");
+    });
   };
 
   updateFocus: (element?: HTMLLIElement | null) => void = (element) => {
@@ -340,7 +361,7 @@ export class NestedNavigation {
       case " ":
         // Check or uncheck checkbox
         this.setSelected(this.currentFocus as HTMLLIElement, inputType);
-        this.setFocusToItem(this.currentFocus)
+        this.setFocusToItem(this.currentFocus);
         doPrevent = true;
         break;
 
@@ -380,13 +401,12 @@ export class NestedNavigation {
       }
       default:
         break;
-      }
+    }
 
-      if(doPrevent === true){
-        ev.preventDefault();
-        ev.stopPropagation();
-      }
-
+    if (doPrevent === true) {
+      ev.preventDefault();
+      ev.stopPropagation();
+    }
   };
 
   private readonly processEndEvent: (ev: KeyboardEvent) => void = (ev) => {

--- a/src/nationalarchives/components/nested-navigation/nested-navigation.ts
+++ b/src/nationalarchives/components/nested-navigation/nested-navigation.ts
@@ -178,6 +178,11 @@ export class NestedNavigation {
     const input = li.querySelector("input");
     if (input) input.checked = !isSelected;
 
+    // If checkbox then we need to deselect a mixed state
+    if (inputType === InputType.checkboxes) {
+      li.setAttribute("aria-checked", !isSelected ? "true" : "false");
+    }
+
     // If radio directory and we're not deselecting a selected radio
     if (inputType === InputType.radios && !isSelected) {
       // For radio buttons, deselect all others
@@ -201,6 +206,7 @@ export class NestedNavigation {
           const children = this.allChildren(childrenGroup, []);
           for (const child of children) {
             child.setAttribute("aria-selected", !isSelected ? "true" : "false");
+            child.setAttribute("aria-checked", !isSelected ? "true" : "false");
             const itemCheckbox = child.getElementsByTagName(
               "input"
             )[0] as HTMLInputElement;

--- a/src/nationalarchives/components/nested-navigation/nested-navigation.ts
+++ b/src/nationalarchives/components/nested-navigation/nested-navigation.ts
@@ -12,6 +12,7 @@ export class NestedNavigation {
   private readonly tree: HTMLUListElement;
   private readonly treeItems: NodeListOf<HTMLElement>;
   private currentFocus: HTMLLIElement | null;
+  private fileSelected: HTMLElement | null;
   private rememberExpanded: Boolean = false;
 
   constructor(tree: HTMLUListElement) {
@@ -183,6 +184,14 @@ export class NestedNavigation {
       localStorage.setItem(`${inputType}-state`, JSON.stringify({ expanded }));
   };
 
+  displaySelected: (filename: string) => void = (filename) => {
+    this.fileSelected =
+      this.fileSelected || document.getElementById(`${this.tree.id}-selected`);
+
+    filename = filename === "" ? "No file selected" : filename;
+    if (this.fileSelected != null) this.fileSelected.textContent = filename;
+  };
+
   setSelected: (li: HTMLLIElement, inputType: InputType) => void = (
     li,
     inputType
@@ -198,6 +207,8 @@ export class NestedNavigation {
     li.setAttribute("aria-selected", !isSelected ? "true" : "false");
     const input = li.querySelector("input");
     if (input) input.checked = !isSelected;
+
+    this.displaySelected(isSelected ? "" : (li.textContent?.trim() as string));
 
     // If checkbox then we need to deselect a mixed state
     if (inputType === InputType.checkboxes) {

--- a/src/nationalarchives/components/nested-navigation/nested-navigation.unit.test.ts
+++ b/src/nationalarchives/components/nested-navigation/nested-navigation.unit.test.ts
@@ -526,24 +526,6 @@ describe.each([InputType.checkboxes, InputType.radios])(
         expect(events.keydown?.length).toEqual(1);
       });
 
-      it("should add click event listeners to the buttons", () => {
-        const events: { [key: string]: EventListenerOrEventListenerObject[] } =
-          {};
-
-        const ul = document.createElement("ul");
-        ul.setAttribute("role", "tree");
-        const button = document.createElement("button");
-        button.classList.add(`js-tree__expander--${classNameValue}`);
-        button.addEventListener = jest.fn((event, callback) => {
-          events[event] = [callback];
-        });
-        ul.appendChild(button);
-        const nestedNavigation = createNestedNavigation({}, undefined, ul);
-        nestedNavigation.initialiseFormListeners(classNameValue);
-
-        expect(events.click?.length).toEqual(1);
-      });
-
       it("should update the expanded state for the checkboxes", () => {
         const tree = document.createElement("ul");
         const input = createInputElement();

--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -88,5 +88,8 @@
         {{ navigationItem(node, params.inputType, className, 1, loop.length, loop.index) }}
       {% endfor %}
     </ul>
+    {% if params.inputType == 'radio' %}
+      <div aria-atomic="true" aria-live="assertive" class="govuk-inset-text">File selected: <span class="govuk-!-font-weight-bold" id="{{ params.inputType }}-tree-selected">No file selected</span></div>
+    {% endif %}
   </div>
 </div>

--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -1,3 +1,9 @@
+{% if params.inputType == 'radio' %}
+  {% set className = 'radios' %}
+{% elseif params.inputType == 'checkbox' %}
+  {% set className = 'checkboxes' %}
+{% endif %}
+
 {% macro input(labelName, id, inputType, className) %}
   <div class="tna-tree__node-item__{{ inputType }} govuk-{{ className }}__item">
     <input
@@ -40,23 +46,21 @@
           id="{{ className }}-expander-{{ item.id }}">
           <span aria-hidden="true" class="govuk-visually-hidden">Expand</span>
         </span>
-
-        {% if inputType == 'checkbox' %}
+        {%- if inputType == 'checkbox' -%}
           {{ input(item.name, item.id, inputType, className) }}
-        {% else %}
+        {%- else -%}
           <div class="js-radios-directory tna-tree__radios-directory">
             <span class="govuk-label tna-tree__radios-directory__label">
               <span class="govuk-visually-hidden">Directory - </span>{{item.name}}
             </span>
           </div>
-        {% endif %}
-
+        {%- endif -%}
       </div>
       <ul class="tna-tree__nested-list tna-tree__nested-list--{{className}}" role="group" id="{{ className }}-node-group-{{ item.id }}">
-        {% set nextLevel = level + 1 %}
-        {% for child in item.children %}
+        {%- set nextLevel = level + 1 -%}
+        {%- for child in item.children -%}
           {{ navigationItem(child, inputType, className, nextLevel, loop.length, loop.index) }}
-        {% endfor %}
+        {%- endfor -%}
       </ul>
     </li>
   {% endif %}
@@ -77,18 +81,13 @@
     </div>
   </details>
   <div class="tna-tree">
-    {% if params.inputType == 'radio' %}
-      {% set className = 'radios' %}
-    {% elseif params.inputType == 'checkbox' %}
-      {% set className = 'checkboxes' %}
-    {% endif %}
-    <ul aria-labelledby="tree-view-label" aria-describedby="tree-view-description" class="tna-tree__root-list" id="{{ params.inputType }}-tree" role="tree"{% if params.inputType == 'checkbox' %} aria-multiselectable="true"{% endif %}>
-      {% for node in params.items %}
+    <ul aria-labelledby="tree-view-label" aria-describedby="tree-view-description" class="tna-tree__root-list" id="{{ params.inputType }}-tree" role="tree"{% if params.inputType == 'checkbox' %} aria-multiselectable="true"{% endif -%}>
+      {%- for node in params.items -%}
         {{ navigationItem(node, params.inputType, className, 1, loop.length, loop.index) }}
-      {% endfor %}
+      {%- endfor -%}
     </ul>
-    {% if params.inputType == 'radio' %}
+    {% if params.inputType == 'radio' -%}
       <div aria-atomic="true" aria-live="assertive" class="govuk-inset-text">File selected: <span class="govuk-!-font-weight-bold" id="{{ params.inputType }}-tree-selected">No file selected</span></div>
-    {% endif %}
+    {%- endif %}
   </div>
 </div>

--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -40,7 +40,7 @@
           class="tna-tree__expander js-tree__expander--{{ className }}"
           tabindex="-1"
           id="{{ className }}-expander-{{ item.id }}">
-          <span class="govuk-visually-hidden">Expand</span>
+          <span aria-hidden="true" class="govuk-visually-hidden">Expand</span>
         </span>
 
         {% if inputType == 'checkbox' %}

--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -86,8 +86,8 @@
         {{ navigationItem(node, params.inputType, className, 1, loop.length, loop.index) }}
       {%- endfor -%}
     </ul>
-    {% if params.inputType == 'radio' -%}
-      <div aria-atomic="true" aria-live="assertive" class="govuk-inset-text">File selected: <span class="govuk-!-font-weight-bold" id="{{ params.inputType }}-tree-selected">No file selected</span></div>
-    {%- endif %}
   </div>
+  {% if params.inputType == 'radio' -%}
+    <div aria-atomic="true" aria-live="assertive" class="govuk-inset-text">File selected: <span class="govuk-!-font-weight-bold" id="{{ params.inputType }}-tree-selected">No file selected</span></div>
+  {%- endif %}
 </div>

--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -68,16 +68,19 @@
   {% endif %}
 {% endmacro %}
 
-<div class="tna-tree">
-  {% if params.inputType == 'radio' %}
-    {% set className = 'radios' %}
-  {% elseif params.inputType == 'checkbox' %}
-    {% set className = 'checkboxes' %}
-  {% endif %}
-
-  <ul aria-label="File selection" aria-describedby="tree-view-description" class="tna-tree__root-list" id="{{ params.inputType }}-tree" role="tree"{% if params.inputType == 'checkbox' %} aria-multiselectable="true"{% endif %}>
-    {% for node in params.items %}
-      {{ navigationItem(node, params.inputType, className, 1, loop.length, loop.index) }}
-    {% endfor %}
-  </ul>
+<div>
+  <h2 class="govuk-heading-m" id="tree-view-label">{{params.label|d("Choose a file")}}</h2>
+  <div class="govuk-inset-text" id="tree-view-description">The arrow keys can be used to navigate through the files. Right and left to open and close a folder. Up and down to move between files and folders. Space or enter to select a file or open and close a folder.</div>
+  <div class="tna-tree">
+    {% if params.inputType == 'radio' %}
+      {% set className = 'radios' %}
+    {% elseif params.inputType == 'checkbox' %}
+      {% set className = 'checkboxes' %}
+    {% endif %}
+    <ul aria-labelledby="tree-view-label" aria-describedby="tree-view-description" class="tna-tree__root-list" id="{{ params.inputType }}-tree" role="tree"{% if params.inputType == 'checkbox' %} aria-multiselectable="true"{% endif %}>
+      {% for node in params.items %}
+        {{ navigationItem(node, params.inputType, className, 1, loop.length, loop.index) }}
+      {% endfor %}
+    </ul>
+  </div>
 </div>

--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -48,7 +48,7 @@
         {% else %}
           <div class="js-radios-directory tna-radios-directory">
             <span class="govuk-label tna-radios-directory__label">
-              <img class="tna-tree__svg-directory" role="img" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyMiI+PHBhdGggZmlsbD0iIzAwMCIgZD0iTTIyIDMuNUgxMC42ODNMOC43NTguODVhMS42NjcgMS42NjcgMCAwIDAtMS4zNS0uNjgzSDJBMS42NjcgMS42NjcgMCAwIDAgLjMzMyAxLjgzM3YxOC4zMzRBMS42NjcgMS42NjcgMCAwIDAgMiAyMS44MzNoMjBhMS42NjcgMS42NjcgMCAwIDAgMS42NjctMS42NjZ2LTE1QTEuNjY2IDEuNjY2IDAgMCAwIDIyIDMuNVptMCAxNi42NjdIMlY2LjgzM2g2LjA5MmExLjY2NyAxLjY2NyAwIDAgMCAxLjY2Ni0xLjY2NkgyVjEuODMzaDUuNDA4bDIuMTc1IDIuOTkyYS44MzMuODMzIDAgMCAwIC42NzUuMzQySDIydjE1WiIvPjwvc3ZnPg==" alt="Directory - "/>
+              <img class="tna-tree__svg-directory" role="img" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAWCAYAAADafVyIAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgB7ZXRDcIgFEWvxgEcoRtUN8ANGIER2KArsAFuABuoIziBbkA3wPdI+iU1iPLHSU5CQ+GGR8IDgIkMZMz4IA/4gQ1vNAwDhBBvk957zAQNj+QTlUSlVMzhnFtOckElu0+TUkporWGMEfTpyBnl3MgzD1ZPwIQQuIS5+ylRoORHLtU3WGuXtSqVaO2SmXEcU6lqSQG8OaWiBVs0pgf0gB7QAwrglsn9eI82nPg15X474f/cyesLxTel2GiK/tEAAAAASUVORK5CYII=" alt="Directory - "/>
               {{item.name}}
             </span>
           </div>

--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -44,10 +44,9 @@
         {% if inputType == 'checkbox' %}
           {{ input(item.name, item.id, inputType, className) }}
         {% else %}
-          <div class="js-radios-directory tna-radios-directory">
-            <span class="govuk-label tna-radios-directory__label">
-              <img class="tna-tree__svg-directory" role="img" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAWCAYAAADafVyIAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAC6SURBVHgB7ZXRDcIgFEWvxgEcoRtUN8ANGIER2KArsAFuABuoIziBbkA3wPdI+iU1iPLHSU5CQ+GGR8IDgIkMZMz4IA/4gQ1vNAwDhBBvk957zAQNj+QTlUSlVMzhnFtOckElu0+TUkporWGMEfTpyBnl3MgzD1ZPwIQQuIS5+ylRoORHLtU3WGuXtSqVaO2SmXEcU6lqSQG8OaWiBVs0pgf0gB7QAwrglsn9eI82nPg15X474f/cyesLxTel2GiK/tEAAAAASUVORK5CYII=" alt="Directory - "/>
-              {{item.name}}
+          <div class="js-radios-directory tna-tree__radios-directory">
+            <span class="govuk-label tna-tree__radios-directory__label">
+              <span class="govuk-visually-hidden">Directory - </span>{{item.name}}
             </span>
           </div>
         {% endif %}

--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -67,7 +67,18 @@
 
 <div>
   <h2 class="govuk-heading-m" id="tree-view-label">{{params.label|d("Choose a file")}}</h2>
-  <div class="govuk-inset-text" id="tree-view-description">The arrow keys can be used to navigate through the files. Right and left to open and close a folder. Up and down to move between files and folders. Space or enter to select a file or open and close a folder.</div>
+  <p class="govuk-body">Select the file you wish to add or edit descriptive metadata.</p>
+
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+      Using the keyboard to choose a file
+      </span>
+    </summary>
+    <div class="govuk-details__text" id="tree-view-description">
+      The arrow keys can be used to navigate and select a file. Right arrow to open and left arrow to close a folder. Up and down arrows to move between files and folders. Space or enter to select a file or open and close a folder.
+    </div>
+  </details>
   <div class="tna-tree">
     {% if params.inputType == 'radio' %}
       {% set className = 'radios' %}

--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -1,3 +1,18 @@
+{% macro input(labelName, id, inputType, className) %}
+  <div class="tna-tree__node-item__{{ inputType }} govuk-{{ className }}__item">
+    <input
+        aria-hidden="true"
+        class="govuk-{{ className }}__input"
+        id="{{ inputType }}-{{ id }}"
+        tabindex="-1"
+        type="{{ inputType }}"
+        name="nested-navigation"/>
+    <label class="govuk-label govuk-{{ className }}__label" for="{{ inputType }}-{{ id }}">
+      {{labelName}}
+    </label>
+  </div>
+{% endmacro %}
+
 {% macro navigationItem(item, inputType, className, level, size, pos) %}
   {% if item.type == 'item' or item.children.length == 0 %}
     <li
@@ -9,12 +24,7 @@
                 aria-posinset="{{pos}}"
                 aria-selected="false"
         >
-      <div class="tna-tree__node-item__{{ inputType }} govuk-{{ className }}__item">
-        <input class="govuk-{{ className }}__input" tabindex="-1" id="{{ inputType }}-{{ item.id }}" type="{{ inputType }}" name="nested-navigation"/>
-        <label class="govuk-label govuk-{{ className }}__label" for="{{ inputType }}-{{ item.id }}">
-          {{item.name}}
-        </label>
-      </div>
+      {{ input(item.name, item.id, inputType, className) }}
     </li>
   {% elif item.type == 'node' %}
     <li
@@ -37,18 +47,7 @@
           <span class="govuk-visually-hidden">Expand</span>
         </span>
         {% if className == 'checkboxes' %}
-          <div class="govuk-{{ className }}__item">
-            <input
-                                class="govuk-{{ className }}__input"
-                                id="{{ inputType }}-{{ item.id }}"
-                                tabindex="-1"
-                                type="{{ inputType }}"
-                                name="nested-navigation"
-/>
-            <label class="govuk-label govuk-{{ className }}__label" for="{{ inputType }}-{{ item.id }}">
-              {{item.name}}
-            </label>
-          </div>
+          {{ input(item.name, item.id, inputType, className) }}
         {% else %}
           <div class="js-radios-directory tna-radios-directory">
             <span class="govuk-label tna-radios-directory__label" >

--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -16,42 +16,39 @@
 {% macro navigationItem(item, inputType, className, level, size, pos) %}
   {% if item.type == 'item' or item.children.length == 0 %}
     <li
-                class="tna-tree__item{% if inputType == "radio" %} govuk-radios--small{% endif %}"
-                role="treeitem"
-                id="{{ className }}-list-{{ item.id }}"
-                aria-level="{{level}}"
-                aria-setsize="{{size}}"
-                aria-posinset="{{pos}}"
-                aria-selected="false"
-        >
+      class="tna-tree__item{% if inputType == "radio" %} govuk-radios--small{% endif %}"
+      role="treeitem"
+      id="{{ className }}-list-{{ item.id }}"
+      aria-level="{{level}}"
+      aria-setsize="{{size}}"
+      aria-posinset="{{pos}}">
       {{ input(item.name, item.id, inputType, className) }}
     </li>
   {% elif item.type == 'node' %}
     <li
-                class="tna-tree__node-item-{{ className }}"
-                role="treeitem"
-                id="{{ className }}-list-{{ item.id }}"
-                aria-expanded="true"
-                aria-selected="false"
-                aria-level="{{level}}"
-                aria-setsize="{{size}}"
-                aria-posinset="{{pos}}"
-        >
+      class="tna-tree__node-item-{{ className }}"
+      role="treeitem"
+      id="{{ className }}-list-{{ item.id }}"
+      aria-expanded="true"
+      {% if inputType == checkbox %}aria-selected="false"{% endif %}
+      aria-level="{{level}}"
+      aria-setsize="{{size}}"
+      aria-posinset="{{pos}}">
       <div class="tna-tree__node-item__container">
         <span
-                        aria-hidden="true"
-                        class="tna-tree__expander js-tree__expander--{{ className }}"
-                        tabindex="-1"
-                        id="{{ className }}-expander-{{ item.id }}"
-                >
+          aria-hidden="true"
+          class="tna-tree__expander js-tree__expander--{{ className }}"
+          tabindex="-1"
+          id="{{ className }}-expander-{{ item.id }}">
           <span class="govuk-visually-hidden">Expand</span>
         </span>
-        {% if className == 'checkboxes' %}
+
+        {% if inputType == 'checkbox' %}
           {{ input(item.name, item.id, inputType, className) }}
         {% else %}
           <div class="js-radios-directory tna-radios-directory">
-            <span class="govuk-label tna-radios-directory__label" >
-              <img class="tna-tree__svg-directory" role="img" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyMiI+PHBhdGggZmlsbD0iIzAwMCIgZD0iTTIyIDMuNUgxMC42ODNMOC43NTguODVhMS42NjcgMS42NjcgMCAwIDAtMS4zNS0uNjgzSDJBMS42NjcgMS42NjcgMCAwIDAgLjMzMyAxLjgzM3YxOC4zMzRBMS42NjcgMS42NjcgMCAwIDAgMiAyMS44MzNoMjBhMS42NjcgMS42NjcgMCAwIDAgMS42NjctMS42NjZ2LTE1QTEuNjY2IDEuNjY2IDAgMCAwIDIyIDMuNVptMCAxNi42NjdIMlY2LjgzM2g2LjA5MmExLjY2NyAxLjY2NyAwIDAgMCAxLjY2Ni0xLjY2NkgyVjEuODMzaDUuNDA4bDIuMTc1IDIuOTkyYS44MzMuODMzIDAgMCAwIC42NzUuMzQySDIydjE1WiIvPjwvc3ZnPg==" alt="Directory"/>
+            <span class="govuk-label tna-radios-directory__label">
+              <img class="tna-tree__svg-directory" role="img" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGZpbGw9Im5vbmUiIHZpZXdCb3g9IjAgMCAyNCAyMiI+PHBhdGggZmlsbD0iIzAwMCIgZD0iTTIyIDMuNUgxMC42ODNMOC43NTguODVhMS42NjcgMS42NjcgMCAwIDAtMS4zNS0uNjgzSDJBMS42NjcgMS42NjcgMCAwIDAgLjMzMyAxLjgzM3YxOC4zMzRBMS42NjcgMS42NjcgMCAwIDAgMiAyMS44MzNoMjBhMS42NjcgMS42NjcgMCAwIDAgMS42NjctMS42NjZ2LTE1QTEuNjY2IDEuNjY2IDAgMCAwIDIyIDMuNVptMCAxNi42NjdIMlY2LjgzM2g2LjA5MmExLjY2NyAxLjY2NyAwIDAgMCAxLjY2Ni0xLjY2NkgyVjEuODMzaDUuNDA4bDIuMTc1IDIuOTkyYS44MzMuODMzIDAgMCAwIC42NzUuMzQySDIydjE1WiIvPjwvc3ZnPg==" alt="Directory - "/>
               {{item.name}}
             </span>
           </div>

--- a/src/nationalarchives/components/nested-navigation/template.njk
+++ b/src/nationalarchives/components/nested-navigation/template.njk
@@ -1,10 +1,8 @@
 {% macro input(labelName, id, inputType, className) %}
   <div class="tna-tree__node-item__{{ inputType }} govuk-{{ className }}__item">
     <input
-        aria-hidden="true"
         class="govuk-{{ className }}__input"
         id="{{ inputType }}-{{ id }}"
-        tabindex="-1"
         type="{{ inputType }}"
         name="nested-navigation"/>
     <label class="govuk-label govuk-{{ className }}__label" for="{{ inputType }}-{{ id }}">


### PR DESCRIPTION
### Essential
- Removing `tabindex` and `aria-hidden` from inputs via JS
	- The JS will now add `aria-hidden="true"` and `tabindex=-1` on the `input` elements for checkbox and radio buttons. They need to not be part of the accessibility tree. This doesn't hide the `label` which contains the text to be announced.
	- NO ACTION ON IMPLEMENTATION
- Add `<details>` component  and reference element `id` in the tree view `aria-describedby` attribute. ([example](https://github.com/nationalarchives/tdr-components/pull/44/files#diff-6eacc87b60c9ca7009d3dd202944e941967e45a99c19c6ced28071699c89f060R73-R82))
- Add aria live region as sibling of tree view as per [here](https://github.com/nationalarchives/tdr-components/pull/44/files#diff-6eacc87b60c9ca7009d3dd202944e941967e45a99c19c6ced28071699c89f060R89-R91)
   - `id` of inner `<span>` must match the tree view id with suffix of `-selected`. e.g. tree view id = `radio-tree` and inner span should be `radio-tree-selected`

### Improvements
All of the items below require some changes to the HTML on implementation.  
- Remove `aria-selected` from radio button directories ([example in njk template](https://github.com/nationalarchives/tdr-components/pull/44/files#diff-6eacc87b60c9ca7009d3dd202944e941967e45a99c19c6ced28071699c89f060R37))
        - this isn't in the TDR Components template but has appeared in integration. 
	- Stops SRs from announcing "selected" on directories which cannot be selected 
- Remove `aria-checked` from all radio buttons
        - this isn't in the TDR Components template but has appeared in integration.  
	- Not part of the spec for a tree view. We only need `aria-selected`
- `aria-checked` should be present on all checkboxes
        - this isn't in the TDR Components template but has appeared in integration. It can stay only on checkboxes/multi-select and not on radios/single select.
	- but in future improvements we should remove it and use a class because it is for visual representation
- Change HTML to remove background image and add visually hidden text: "Directory -"
	- Directory `img` has been replaced by CSS background image. From [this](https://github.com/nationalarchives/tdr-components/pull/44/files#diff-6eacc87b60c9ca7009d3dd202944e941967e45a99c19c6ced28071699c89f060L54-L55) to [this](https://github.com/nationalarchives/tdr-components/pull/44/files#diff-6eacc87b60c9ca7009d3dd202944e941967e45a99c19c6ced28071699c89f060R54). 
- Change radio directory class names to match BEM standards in rest of tree view HTML
  - Change from [`.tna-radios-directory`](https://github.com/nationalarchives/tdr-components/pull/44/files#diff-6eacc87b60c9ca7009d3dd202944e941967e45a99c19c6ced28071699c89f060L53-L54) to [`.tna-tree__radios-directory__label`](https://github.com/nationalarchives/tdr-components/pull/44/files#diff-6eacc87b60c9ca7009d3dd202944e941967e45a99c19c6ced28071699c89f060R53-R54)
- [Add `aria-hidden="true"` to "Expand" text](https://github.com/nationalarchives/tdr-components/compare/TDR-3092?expand=1#diff-6eacc87b60c9ca7009d3dd202944e941967e45a99c19c6ced28071699c89f060R41) within the blue triangle icon 