### PR TITLE
TDR-3152 - Enable checks for pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,9 @@
 name: Run unit & storybook tests
 on:
+  pull_request:
   push:
     branches-ignore:
+      - main
       - release-*
 permissions:
   id-token: write


### PR DESCRIPTION
The version bump pr's were stuck waiting for the checks because we only enabled checks for commits and not on pull requests. This adds this change.