### PR TITLE
GOV.UK frontend upgrade from version 4 to 5

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -50,10 +50,10 @@ const config = {
           loader: "sass-loader",
           options: {
             additionalData: `
-              @import "govuk-frontend/govuk/base";
-              @import "govuk-frontend/govuk/settings/all";
-              @import "govuk-frontend/govuk/tools/all";
-              @import "govuk-frontend/govuk/helpers/all";
+              @import "govuk-frontend/dist/govuk/base";
+              @import "govuk-frontend/dist/govuk/settings/all";
+              @import "govuk-frontend/dist/govuk/tools/all";
+              @import "govuk-frontend/dist/govuk/helpers/all";
             `,
             implementation: require("sass"),
           },

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -11,4 +11,13 @@ const preview = {
   },
 };
 
+// Add the required GOV.UK Frontend classes to the body
+if (typeof window !== 'undefined' && document.body) {
+  document.body.className +=
+    ' js-enabled' +
+    ('noModule' in HTMLScriptElement.prototype
+      ? ' govuk-frontend-supported'
+      : '');
+}
+
 export default preview;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.0.0",
       "license": "ISC",
       "dependencies": {
-        "govuk-frontend": "^4.9.0"
+        "govuk-frontend": "^5.7.1"
       },
       "devDependencies": {
         "@babel/core": "^7.26.0",
@@ -9474,9 +9474,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.9.0.tgz",
-      "integrity": "sha512-zfX+GBUKpWBeV6JwCIawEuI8VRWlskH8Ok8aNUjKOvzo3zIaNbcrv4IOwgy+oSnMoGh67Eeh+vb7+9GFxN2fNg==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-5.7.1.tgz",
+      "integrity": "sha512-jF1cq5rn57kxZmJRprUZhTQ31zaBBK4b5AyeJaPX3Yhg22lk90Mx/dQLvOk/ycV3wM7e0y+s4IPvb2fFaPlCGg==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,6 @@
     "yaml-loader": "^0.8.1"
   },
   "dependencies": {
-    "govuk-frontend": "^4.9.0"
+    "govuk-frontend": "^5.7.1"
   }
 }

--- a/src/nationalarchives/all.scss
+++ b/src/nationalarchives/all.scss
@@ -1,3 +1,3 @@
 @import "overrides";
-@import "govuk-frontend/govuk/all";
+@import "govuk-frontend/dist/govuk/all";
 @import "components";

--- a/src/nationalarchives/components/alert/alert.scss
+++ b/src/nationalarchives/components/alert/alert.scss
@@ -1,5 +1,5 @@
-@import "govuk-frontend/govuk/settings/all";
-@import "govuk-frontend/govuk/tools/all";
-@import "govuk-frontend/govuk/helpers/all";
-@import "govuk-frontend/govuk/components/inset-text";
+@import "govuk-frontend/dist/govuk/settings/all";
+@import "govuk-frontend/dist/govuk/tools/all";
+@import "govuk-frontend/dist/govuk/helpers/all";
+@import "govuk-frontend/dist/govuk/components/inset-text";
 @import "index";

--- a/src/nationalarchives/components/alert/alert.stories.ts
+++ b/src/nationalarchives/components/alert/alert.stories.ts
@@ -1,4 +1,3 @@
-// import "govuk-frontend/govuk/components/inset-text";
 import "../icon/_index.scss";
 import "./_index.scss";
 import iconStory from "../icon/icon.stories";

--- a/src/nationalarchives/components/card/card.scss
+++ b/src/nationalarchives/components/card/card.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend/govuk/settings/all";
-@import "govuk-frontend/govuk/tools/all";
-@import "govuk-frontend/govuk/helpers/all";
+@import "govuk-frontend/dist/govuk/settings/all";
+@import "govuk-frontend/dist/govuk/tools/all";
+@import "govuk-frontend/dist/govuk/helpers/all";
 @import "index";

--- a/src/nationalarchives/components/header/header.scss
+++ b/src/nationalarchives/components/header/header.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend/govuk/settings/all";
-@import "govuk-frontend/govuk/tools/all";
-@import "govuk-frontend/govuk/helpers/all";
+@import "govuk-frontend/dist/govuk/settings/all";
+@import "govuk-frontend/dist/govuk/tools/all";
+@import "govuk-frontend/dist/govuk/helpers/all";
 @import "index";

--- a/src/nationalarchives/components/header/header.stories.ts
+++ b/src/nationalarchives/components/header/header.stories.ts
@@ -19,14 +19,17 @@ export default {
     (storyFn) => {
       // Create an element that centres element with margin.
       const wrapper = document.createElement("div");
-      wrapper.classList.add("js-enabled");
       const parser = new DOMParser();
       const doc = parser.parseFromString(storyFn() as string, "text/html");
       wrapper.append(...doc.body.children);
-
       const header = wrapper.querySelector('[data-module="govuk-header"]');
       if (header !== null) {
-        new Header(header).init();
+        // Necessary because of the order in which decorators are 
+        // applied. If the timeout isn't present Header() will not 
+        // find any navigation items.  
+        setTimeout(() => {
+          new Header(header);
+        }, 0);
       }
 
       return wrapper;

--- a/src/nationalarchives/components/header/header.stories.ts
+++ b/src/nationalarchives/components/header/header.stories.ts
@@ -24,9 +24,9 @@ export default {
       wrapper.append(...doc.body.children);
       const header = wrapper.querySelector('[data-module="govuk-header"]');
       if (header !== null) {
-        // Necessary because of the order in which decorators are 
-        // applied. If the timeout isn't present Header() will not 
-        // find any navigation items.  
+        // Necessary because of the order in which decorators are
+        // applied. If the timeout isn't present Header() will not
+        // find any navigation items.
         setTimeout(() => {
           new Header(header);
         }, 0);

--- a/src/nationalarchives/components/icon/icon.scss
+++ b/src/nationalarchives/components/icon/icon.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend/govuk/settings/all";
-@import "govuk-frontend/govuk/tools/all";
-@import "govuk-frontend/govuk/helpers/all";
+@import "govuk-frontend/dist/govuk/settings/all";
+@import "govuk-frontend/dist/govuk/tools/all";
+@import "govuk-frontend/dist/govuk/helpers/all";
 @import "index";

--- a/src/nationalarchives/components/multi-select-search/multi-select-search.scss
+++ b/src/nationalarchives/components/multi-select-search/multi-select-search.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend/govuk/settings/all";
-@import "govuk-frontend/govuk/tools/all";
-@import "govuk-frontend/govuk/helpers/all";
+@import "govuk-frontend/dist/govuk/settings/all";
+@import "govuk-frontend/dist/govuk/tools/all";
+@import "govuk-frontend/dist/govuk/helpers/all";
 @import "index";

--- a/src/nationalarchives/components/nested-navigation/nested-navigation.scss
+++ b/src/nationalarchives/components/nested-navigation/nested-navigation.scss
@@ -1,4 +1,4 @@
-@import "govuk-frontend/govuk/settings/all";
-@import "govuk-frontend/govuk/tools/all";
-@import "govuk-frontend/govuk/helpers/all";
+@import "govuk-frontend/dist/govuk/settings/all";
+@import "govuk-frontend/dist/govuk/tools/all";
+@import "govuk-frontend/dist/govuk/helpers/all";
 @import "index";

--- a/src/nationalarchives/govuk.scss
+++ b/src/nationalarchives/govuk.scss
@@ -1,2 +1,2 @@
-@import "govuk-frontend/govuk/all";
+@import "govuk-frontend/dist/govuk/all";
 @import "overrides";


### PR DESCRIPTION
_**This PR also includes the linting fix**_

There are a couple of minor changes needed to get this working:

- Change imports from e.g. `"govuk-frontend/govuk/base"` to `"govuk-frontend/dist/govuk/base"`
- Add JS to top of `<body>` to init JS only in supported browser - [docs](https://frontend.design-system.service.gov.uk/import-javascript/#before-you-start)
- Init'ing a module slightly differently - I think we only do this with header atm. - [docs](https://frontend.design-system.service.gov.uk/import-javascript/#import-individual-components)
  - e.g.  from `new Header(element).init()` to `new Header(element)`

[Benefits of updating to v5](https://frontend.design-system.service.gov.uk/changes-to-govuk-frontend-v5/#benefits-of-updating-to-v5)

- find it easier to make future changes to comply with WCAG 2.2 accessibility requirements
- have the option to use the new task list component
- import less code to your project as our JavaScript code is 25% smaller and our CSS is 5% smaller
- only run JavaScript in browsers where GOV.UK Frontend is supported which reduces the load in older browsers
- see new error messages that explain when our components fail to initialise

